### PR TITLE
BUG: fixes #20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         # to-do: remove hard-coding of version
-        activate-environment: q2-hello-world-qiime2-tiny-2024.2
-        environment-file: q2-hello-world/environments/q2-hello-world-qiime2-tiny-2024.2.yml
+        activate-environment: q2-hello-world-qiime2-tiny-2024.5
+        environment-file: q2-hello-world/environments/q2-hello-world-qiime2-tiny-2024.5.yml
         auto-activate-base: false
 
     - name: Install plugin

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "package_name": "q2-hello-world",
     "module_name": "{{ cookiecutter.package_name.replace('-', '_') }}",
-    "plugin_name": "{{ cookiecutter.package_name.lstrip('q2-') }}",
+    "plugin_name": "{{ cookiecutter.package_name.removeprefix('q2-') }}",
     "author_name": "A QIIME 2 Plugin Developer",
     "author_email": "q2-dev@example.com",
     "project_url": "https://example.com",


### PR DESCRIPTION
This fixes the issue with leading `q`, `2`, and `-` characters being stripped from plugin names.

```shell
  [1/10] Package name (e.g., used as the top-level directory name) (q2-hello-world): q2-qsip2
  [2/10] Module name (must be a valid Python identifier) (q2_qsip2):
  [3/10] Plugin name (often a shortened version of the package name) (qsip2):
  ...
(q2-boots-2024.10.dev) ➜  temp cd q2-qsip2

(q2-boots-2024.10.dev) ➜  q2-qsip2 git:(main) make dev
...
(q2-boots-2024.10.dev) ➜  q2-qsip2 git:(main) make test
...
2 passed, 7 warnings in 5.63s 
```