### PR TITLE
Update plugin-level citation comment

### DIFF
--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
@@ -20,8 +20,9 @@ plugin = Plugin(
     package="{{ cookiecutter.module_name }}",
     description="{{ cookiecutter.plugin_description }}",
     short_description="{{ cookiecutter.plugin_short_description }}",
-    # The plugin-level citation of 'Caporaso-Bolyen-2024' is provided as an example.
-    # You can replace this with citations to other references in citations.bib
+    # The plugin-level citation of 'Caporaso-Bolyen-2024' is provided as
+    # an example. You can replace this with citations to other references 
+    # in citations.bib.
     citations=[citations['Caporaso-Bolyen-2024']]
 )
 

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
@@ -21,7 +21,7 @@ plugin = Plugin(
     description="{{ cookiecutter.plugin_description }}",
     short_description="{{ cookiecutter.plugin_short_description }}",
     # The plugin-level citation of 'Caporaso-Bolyen-2024' is provided as
-    # an example. You can replace this with citations to other references 
+    # an example. You can replace this with citations to other references
     # in citations.bib.
     citations=[citations['Caporaso-Bolyen-2024']]
 )

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin_setup.py
@@ -20,9 +20,8 @@ plugin = Plugin(
     package="{{ cookiecutter.module_name }}",
     description="{{ cookiecutter.plugin_description }}",
     short_description="{{ cookiecutter.plugin_short_description }}",
-    # Please retain the plugin-level citation of 'Caporaso-Bolyen-2024'
-    # as attribution of the use of this template, in addition to any citations
-    # you add.
+    # The plugin-level citation of 'Caporaso-Bolyen-2024' is provided as an example.
+    # You can replace this with citations to other references in citations.bib
     citations=[citations['Caporaso-Bolyen-2024']]
 )
 


### PR DESCRIPTION
The comments about citing the dev docs seem a bit strange in the template. This is something that developers who use this template should cite in their repo and any article(s) as a template for their plugin. 

But a plugin-level citation then passes this on to the users; so the comment about keeping this plugin-level citation implies that all users of that plugin should also be citing the dev docs. This does not seem appropriate, as the users did not use the dev docs in their research.

Discussed with @gregcaporaso out of loop.
