### PR TITLE
BUG: Fix typo in version file path

### DIFF
--- a/template/{{ package_name }}/pyproject.toml
+++ b/template/{{ package_name }}/pyproject.toml
@@ -36,7 +36,7 @@ dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.versioningit.write]
-file = "{{ package_name }}/_version.py"
+file = "{{ module_name }}/_version.py"
 
 [tool.versioningit]
 default-version = "0.0.dev0"


### PR DESCRIPTION
I'm not 100% sure what's going on with the versioning, but I'm pretty sure this is a typo? Please ignore if I am wrong and confused!