### PR TITLE
BUG: set up versioningit to see Github release tags

### DIFF
--- a/template/{{ package_name }}/pyproject.toml
+++ b/template/{{ package_name }}/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]
 method = "git-archive"
-describe-subst = "$Format:%(describe)$"
+describe-subst = "$Format:%(describe:tags)$"
 default-tag = "0.0.1"
 
 [tool.versioningit.next-version]


### PR DESCRIPTION
By default unannotated tags are not considered by versioningit.