### PR TITLE
MAINT: update CI workflow to use `macos-15-intel` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15-intel]
 
     steps:
     - name: checkout source

--- a/template/{{ package_name }}/.github/workflows/ci.yml
+++ b/template/{{ package_name }}/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ '{{' }} matrix.os {{ '}}' }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15-intel]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
@lizgehret - is this right? I got an error about the previous runner no longer being available. 